### PR TITLE
Implement login/signup features

### DIFF
--- a/ZenFlow.Server/Controllers/AuthController.cs
+++ b/ZenFlow.Server/Controllers/AuthController.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace ZenFlow.Server.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class AuthController : ControllerBase
+    {
+        private static readonly Dictionary<string, string> _users = new();
+
+        [HttpPost("signup")]
+        public IActionResult Signup([FromBody] LoginRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(request.Username) || string.IsNullOrWhiteSpace(request.Password))
+            {
+                return BadRequest("Username and password are required.");
+            }
+
+            if (_users.ContainsKey(request.Username))
+            {
+                return Conflict("User already exists.");
+            }
+
+            _users[request.Username] = request.Password;
+            return Ok();
+        }
+
+        [HttpPost("login")]
+        public IActionResult Login([FromBody] LoginRequest request)
+        {
+            if (_users.TryGetValue(request.Username, out var password) && password == request.Password)
+            {
+                return Ok();
+            }
+
+            return Unauthorized();
+        }
+    }
+
+    public record LoginRequest(string Username, string Password);
+}

--- a/zenflow.client/CHANGELOG.md
+++ b/zenflow.client/CHANGELOG.md
@@ -9,7 +9,7 @@ The following steps were used to generate this project:
 - Add `aspnetcore-https.js` script to install https certs.
 - Update `package.json` to call `aspnetcore-https.js` and serve with https.
 - Update `angular.json` to point to `proxy.conf.js`.
-- Update `app.component.ts` component to fetch and display weather information.
+- Update `app.component.ts` to host the application shell and routing.
 - Modify `app.component.spec.ts` with updated tests.
 - Update `app.module.ts` to import the HttpClientModule.
 - Create project file (`zenflow.client.esproj`).

--- a/zenflow.client/src/app/app-routing.module.ts
+++ b/zenflow.client/src/app/app-routing.module.ts
@@ -1,7 +1,13 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './auth/login/login.component';
+import { SignupComponent } from './auth/signup/signup.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: 'login', component: LoginComponent },
+  { path: 'signup', component: SignupComponent },
+  { path: '**', redirectTo: 'login' }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/zenflow.client/src/app/app.component.html
+++ b/zenflow.client/src/app/app.component.html
@@ -2,14 +2,6 @@
   <app-sidebar></app-sidebar>
 
   <div class="main-content">
-    <p>hello god</p>
-
-    <app-button label="Submit Form" variant="primary"></app-button>
-    <app-button label="Cancel" variant="danger" customClass="margin-left-10"></app-button>
-    <app-button label="Download" icon="fas fa-download" variant="success" iconPosition="left"></app-button>
-    <app-button label="Search" icon="fas fa-search" customClass="round-corners"></app-button>
-    <app-button icon="fas fa-house"></app-button>
-
-    <app-input [(value)]="myValue" placeholder="Type something..."></app-input>
+    <router-outlet></router-outlet>
   </div>
 </div>

--- a/zenflow.client/src/app/app.component.ts
+++ b/zenflow.client/src/app/app.component.ts
@@ -8,5 +8,4 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'zenflow';
-  myValue: string = '';
 }

--- a/zenflow.client/src/app/app.module.ts
+++ b/zenflow.client/src/app/app.module.ts
@@ -1,17 +1,23 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ButtonComponent } from './components/button/button.component';
+import { LoginComponent } from './auth/login/login.component';
+import { SignupComponent } from './auth/signup/signup.component';
  
 import { InputComponent } from './components/input/input.component';
 import { SidebarComponent } from './components/sidebar/sidebar.component';
 
 @NgModule({
-  declarations: [AppComponent, InputComponent, SidebarComponent], // ✅ ButtonComponent çıkarıldı
+  declarations: [AppComponent, InputComponent, SidebarComponent, LoginComponent, SignupComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,
+    FormsModule,
+    HttpClientModule,
     ButtonComponent
   ],
   providers: [],

--- a/zenflow.client/src/app/auth/login/login.component.css
+++ b/zenflow.client/src/app/auth/login/login.component.css
@@ -1,0 +1,1 @@
+.error { color: red; }

--- a/zenflow.client/src/app/auth/login/login.component.html
+++ b/zenflow.client/src/app/auth/login/login.component.html
@@ -1,0 +1,6 @@
+<form (ngSubmit)="onSubmit()">
+  <input name="username" [(ngModel)]="username" placeholder="Username" required>
+  <input name="password" [(ngModel)]="password" placeholder="Password" type="password" required>
+  <button type="submit">Login</button>
+</form>
+<p *ngIf="error" class="error">{{ error }}</p>

--- a/zenflow.client/src/app/auth/login/login.component.ts
+++ b/zenflow.client/src/app/auth/login/login.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.css']
+})
+export class LoginComponent {
+  username = '';
+  password = '';
+  error = '';
+
+  constructor(private authService: AuthService) {}
+
+  onSubmit() {
+    this.authService.login(this.username, this.password).subscribe({
+      next: () => {
+        this.error = '';
+      },
+      error: () => {
+        this.error = 'Invalid credentials';
+      }
+    });
+  }
+}

--- a/zenflow.client/src/app/auth/signup/signup.component.css
+++ b/zenflow.client/src/app/auth/signup/signup.component.css
@@ -1,0 +1,2 @@
+.error { color: red; }
+.success { color: green; }

--- a/zenflow.client/src/app/auth/signup/signup.component.html
+++ b/zenflow.client/src/app/auth/signup/signup.component.html
@@ -1,0 +1,7 @@
+<form (ngSubmit)="onSubmit()">
+  <input name="username" [(ngModel)]="username" placeholder="Username" required>
+  <input name="password" [(ngModel)]="password" placeholder="Password" type="password" required>
+  <button type="submit">Signup</button>
+</form>
+<p *ngIf="error" class="error">{{ error }}</p>
+<p *ngIf="success" class="success">{{ success }}</p>

--- a/zenflow.client/src/app/auth/signup/signup.component.ts
+++ b/zenflow.client/src/app/auth/signup/signup.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { AuthService } from '../../services/auth.service';
+
+@Component({
+  selector: 'app-signup',
+  templateUrl: './signup.component.html',
+  styleUrls: ['./signup.component.css']
+})
+export class SignupComponent {
+  username = '';
+  password = '';
+  error = '';
+  success = '';
+
+  constructor(private authService: AuthService) {}
+
+  onSubmit() {
+    this.authService.signup(this.username, this.password).subscribe({
+      next: () => {
+        this.success = 'Account created';
+        this.error = '';
+      },
+      error: (err) => {
+        this.error = err.error || 'Signup failed';
+        this.success = '';
+      }
+    });
+  }
+}

--- a/zenflow.client/src/app/components/button/button.component.ts
+++ b/zenflow.client/src/app/components/button/button.component.ts
@@ -23,6 +23,7 @@ export class ButtonComponent {
   @Input() disabled: boolean = false;
   @Input() sidebar: boolean = false;
   @Input() selected: boolean = false;
+  @Input() customClass: string = '';
   @Output() clickEvent = new EventEmitter<void>();
 
   get buttonClasses(): string[] {
@@ -37,6 +38,10 @@ export class ButtonComponent {
       classes.push('btn');
       classes.push(`btn-${this.variant}`);
       classes.push(`btn-${this.size}`);
+    }
+
+    if (this.customClass) {
+      classes.push(this.customClass);
     }
 
     return classes;

--- a/zenflow.client/src/app/components/input/input.component.spec.ts
+++ b/zenflow.client/src/app/components/input/input.component.spec.ts
@@ -13,6 +13,7 @@ describe('InputComponent', () => {
 
     fixture = TestBed.createComponent(InputComponent);
     component = fixture.componentInstance;
+    spyOn(component.valueChange, 'emit');
     fixture.detectChanges();
     inputElement = fixture.nativeElement.querySelector('input');
   });

--- a/zenflow.client/src/app/components/sidebar/sidebar.component.html
+++ b/zenflow.client/src/app/components/sidebar/sidebar.component.html
@@ -11,6 +11,24 @@
         </app-button>
       </li>
 
+      <li class="nav-item">
+        <app-button [label]="'Login'"
+                    [icon]="'fas fa-sign-in-alt'"
+                    [sidebar]="true"
+                    [selected]="isActive('/login')"
+                    (clickEvent)="navigateTo('/login')">
+        </app-button>
+      </li>
+
+      <li class="nav-item">
+        <app-button [label]="'Signup'"
+                    [icon]="'fas fa-user-plus'"
+                    [sidebar]="true"
+                    [selected]="isActive('/signup')"
+                    (clickEvent)="navigateTo('/signup')">
+        </app-button>
+      </li>
+
       <li class="nav-item dropdown-container">
         <app-button [label]="'Profile'"
                     [icon]="'fas fa-user'"

--- a/zenflow.client/src/app/services/auth.service.ts
+++ b/zenflow.client/src/app/services/auth.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private apiUrl = '/api/auth';
+
+  constructor(private http: HttpClient) {}
+
+  login(username: string, password: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/login`, { username, password });
+  }
+
+  signup(username: string, password: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/signup`, { username, password });
+  }
+}

--- a/zenflow.client/tsconfig.app.json
+++ b/zenflow.client/tsconfig.app.json
@@ -1,4 +1,4 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about TypeScript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
 /* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "./tsconfig.json",

--- a/zenflow.client/tsconfig.json
+++ b/zenflow.client/tsconfig.json
@@ -1,4 +1,4 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about TypeScript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
 /* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "compileOnSave": false,

--- a/zenflow.client/tsconfig.spec.json
+++ b/zenflow.client/tsconfig.spec.json
@@ -1,4 +1,4 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
+/* To learn more about TypeScript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
 /* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "./tsconfig.json",


### PR DESCRIPTION
## Summary
- add minimal AuthController in server
- add AuthService and login/signup components in Angular app
- wire login and signup routes
- update sidebar and app shell to support routing
- fix tsconfig typo and update changelog
- allow InputComponent tests to spy on value changes

## Testing
- `npm install --force`
- `npm test --silent` *(fails: No binary for Chrome browser)*
- `dotnet build ZenFlow.Server/ZenFlow.Server.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de8a82f90832eaac9fe2e9e990b0b